### PR TITLE
intel compiler package name change

### DIFF
--- a/Docker/Dockerfile.intel-oneapi-hpckit-ubuntu20
+++ b/Docker/Dockerfile.intel-oneapi-hpckit-ubuntu20
@@ -15,7 +15,7 @@ RUN apt-get update -y && \
     intel-oneapi-common-licensing \
     intel-oneapi-common-vars \
     intel-oneapi-dev-utilities \
-    intel-oneapi-dpcpp-cpp-compiler-pro \
+    intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic \
     intel-oneapi-ifort \
     intel-oneapi-inspector \
     intel-oneapi-itac \


### PR DESCRIPTION
For the 2021.1 release, intel has renamed some of the oneapi packages.
intel-oneapi-dpcpp-cpp-compiler-pro is now intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
it contains icc, icx, icpc, icpx, & dpcpp
